### PR TITLE
remove redundant .kv builder

### DIFF
--- a/wandering-warriors/main.py
+++ b/wandering-warriors/main.py
@@ -1,5 +1,4 @@
 from kivy.app import App
-from kivy.lang import Builder
 from kivy.uix.screenmanager import ScreenManager, Screen
 from kivy.uix.widget import Widget
 
@@ -46,7 +45,6 @@ class Screen:
 
 class CalculatorApp(App):
     def build(self):
-        Builder.load_file("calculator.kv")
         return Screen().get_manager()
 
 


### PR DESCRIPTION
Fix for startup warning: ".../calculator.kv is loaded multiples times."  When the .kv file was renamed to match CalculatorApp(App), it gets imported automatically.  This makes the Builder redundant, and only necessary if we want more than one .kv file.