### PR TITLE
Abacus Animator

### DIFF
--- a/wandering-warriors/modules/abacus.py
+++ b/wandering-warriors/modules/abacus.py
@@ -11,7 +11,7 @@ from time import sleep
 class Bead(Rectangle):
     def __init__(self, **kwargs):
         super(Bead, self).__init__(source='assets/graphics/bead.png', **kwargs)
-        
+
         self.anim = None
 
     def get_anim_offset(self):
@@ -74,6 +74,7 @@ class AbacusAnim:
             n_beads = len(column.up)
 
         self.down_shifts.append((column, n_beads))
+
 
 class Abacus(FloatLayout):
     MAX_BAR_W = 10
@@ -201,18 +202,22 @@ class Abacus(FloatLayout):
             for j in range(len(top_beads.down)):
                 bead = top_beads.down[j]
 
+                anim_offset = floor(bead_space * bead.get_anim_offset())
+
                 bead.pos = (
                     bead_x,
-                    self.y + self.height - border_w - bead_w / 2 - j * bead_w / 2 - floor(bead_space * bead.get_anim_offset())
+                    self.y + self.height - border_w - bead_w / 2 - j * bead_w / 2 - anim_offset
                 )
                 bead.size = (bead_w, bead_w / 2)
 
             for j in range(len(top_beads.up)):
                 bead = top_beads.up[j]
 
+                anim_offset = floor(bead_space * bead.get_anim_offset())
+
                 bead.pos = (
                     bead_x,
-                    div_y + border_w + bead_w / 2 * (len(top_beads.up) - j - 1) + floor(bead_space * bead.get_anim_offset())
+                    div_y + border_w + bead_w / 2 * (len(top_beads.up) - j - 1) + anim_offset
                 )
                 bead.size = (bead_w, bead_w / 2)
 
@@ -221,13 +226,20 @@ class Abacus(FloatLayout):
             for j in range(len(bottom_beads.down)):
                 bead = bottom_beads.down[j]
 
-                bead.pos = (bead_x, self.y + border_w + (len(bottom_beads.down) - j - 1) * bead_w / 2 + floor(bead_space * bead.get_anim_offset()))
+                anim_offset = floor(bead_space * bead.get_anim_offset())
+
+                bead.pos = (
+                    bead_x,
+                    self.y + border_w + (len(bottom_beads.down) - j - 1) * bead_w / 2 + anim_offset
+                )
                 bead.size = (bead_w, bead_w / 2)
 
             for j in range(len(bottom_beads.up)):
                 bead = bottom_beads.up[j]
 
-                bead.pos = (bead_x, div_y - bead_w / 2 * (len(bottom_beads.up) - j) - floor(bead_space * bead.get_anim_offset()))
+                anim_offset = floor(bead_space * bead.get_anim_offset())
+
+                bead.pos = (bead_x, div_y - bead_w / 2 * (len(bottom_beads.up) - j) - anim_offset)
                 bead.size = (bead_w, bead_w / 2)
 
     def get_value(self):
@@ -273,7 +285,7 @@ class Abacus(FloatLayout):
                     bead.anim = None
 
             self.update()
-        
+
         return f
 
     # animations
@@ -330,4 +342,3 @@ class Abacus(FloatLayout):
                 anim.add_shift_down(self.bottom_beads[i], -1)
 
         return self.build_anim(anim)
-    

--- a/wandering-warriors/modules/abacus.py
+++ b/wandering-warriors/modules/abacus.py
@@ -3,7 +3,7 @@ from kivy.uix.floatlayout import FloatLayout
 
 from math import floor
 
-from threading import Thread, Timer
+from threading import Thread
 
 from time import sleep
 

--- a/wandering-warriors/modules/abacus.py
+++ b/wandering-warriors/modules/abacus.py
@@ -41,8 +41,8 @@ class Abacus(FloatLayout):
     MAX_BEAD_SPACING = 8
 
     N_BARS = 12
-    N_TOP_BEADS = 1
-    N_BOTTOM_BEADS = 4
+    N_TOP_BEADS = 2
+    N_BOTTOM_BEADS = 5
 
     def __init__(self, **kwargs):
         super(Abacus, self).__init__(**kwargs)
@@ -84,17 +84,8 @@ class Abacus(FloatLayout):
             # temp tests
 
             self.top_beads[1].shift_up(1)
-            self.top_beads[3].shift_up(1)
-            self.top_beads[6].shift_up(1)
 
-            self.bottom_beads[0].shift_up(3)
-            self.bottom_beads[1].shift_up(1)
-            self.bottom_beads[4].shift_up(4)
-            self.bottom_beads[7].shift_up(2)
-
-            self.top_beads[3].shift_down(1)
-
-            self.bottom_beads[0].shift_down(1)
+            print(self.get_value())
 
         self.bind(pos=self.update, size=self.update)
         self.update()
@@ -189,3 +180,19 @@ class Abacus(FloatLayout):
             for j in range(len(bottom_beads.up)):
                 bottom_beads.up[j].pos = (bead_x, div_y - bead_w / 2 * (len(bottom_beads.up) - j))
                 bottom_beads.up[j].size = (bead_w, bead_w / 2)
+
+    def get_value(self):
+        v = 0
+
+        top_v = self.N_BOTTOM_BEADS + 1
+        place = (self.N_TOP_BEADS + 1) * top_v
+
+        for i in range(self.N_BARS, 0, -1):
+            i -= 1
+
+            top_beads = self.top_beads[i]
+            bottom_beads = self.bottom_beads[i]
+
+            v += place ** i * (len(top_beads.up) * top_v + len(bottom_beads.up))
+
+        return v


### PR DESCRIPTION
Provides a base for the abacus animations as well as the reset and preset animations (preset(x) animates counting x on the abacus). The abacus animator is based around threads.

To create an animation:
 - instantiate an instance of the AbacusAnim class
 - select beads to move using AbacusAnim.add_shift_up and AbacusAnim.add_shift_down which each take an AbacusColumn object (get these from self.top_beads and self.bottom_beads) and an integer number of beads to move; passing -1 will shift all of the beads in the specified column.
 - call self.build_anim on your AbacusAnim (self.build_anim produces a function which when used as the target of a thread will run the animation on the abacus)
 - return a function which when run as a thread will produce your animation (this may be the result of self.build_anim in simple cases like reset or preset or another function which runs multiple threads)

Example: 
```
def add(x, y):
  def f():
    preset_x = Thread(self.preset(x))
    preset_x.start()
    preset_x.join()

    sleep(1)

    for each digit in y:
      a = AbacusAnim()
      add up shifts
      ta = Thread(self.build_anim(a))
      ta.start()
      ta.join()

      sleep(1)

      if need to carry:
        while carrying:
          a = AbacusAnim()
          add down shifts
          add up shifts
          ta = Thread(self.build_anim(a))
          ta.start()
          ta.join()

          sleep(1)

  return f

Thread(target=self.add(1234, 5678)).start() # probably in some other handler
```

https://trello.com/c/kVCEaxUD/42-reset-animation-for-abacus
https://trello.com/c/U7GlYNU2/40-transitions-for-bead-movement
https://trello.com/c/RUIdtRNF/41-create-an-abacus-animator