### PR TITLE
Abacus Animator Queue Option

### DIFF
--- a/wandering-warriors/modules/abacus.py
+++ b/wandering-warriors/modules/abacus.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from kivy.graphics import Color, Rectangle
 from kivy.uix.floatlayout import FloatLayout
 
@@ -126,6 +128,8 @@ class Abacus(FloatLayout):
 
                 self.top_beads.append(AbacusColumn(self.N_TOP_BEADS))
                 self.bottom_beads.append(AbacusColumn(self.N_BOTTOM_BEADS))
+
+        self.anim_queue = deque([])
 
         self.bind(pos=self.update, size=self.update)
         self.update()
@@ -287,6 +291,21 @@ class Abacus(FloatLayout):
             self.update()
 
         return f
+
+    def enqueue_anim(self, anim):
+        self.anim_queue.append(anim)
+
+    def play_anims_from_queue(self):
+        def f():
+            while len(self.anim_queue) > 0:
+                ta = Thread(target=self.anim_queue.popleft()())
+                ta.start()
+                ta.join()
+
+                sleep(1)
+
+        t = Thread(target=f)
+        t.start()
 
     # animations
 


### PR DESCRIPTION
To avoid having to interface with threads, you can now instead simply add animations to a queue and then play them as a sequence using self.enqueue_anim and self.play_anims_from_queue. Note that self.enqueue_anim takes a function that returns a function. This can simply be a lambda around a built animation (from self.build_anim, which still must be called manually), see Example 1 or another function that returns a built animation, see Example 2. This is because when an animation depends on a previous one, it must be built after the previous animation has been completed, not before.

Example 1:
```
self.enqueue_anim(lambda : self.preset(1234))
self.enqueue_anim(lambda : self.reset())
self.play_anims_from_queue()
```

Example 2:
```
for i in range(4):
    def get_anim():
        anim = AbacusAnim()
        anim.add_shift_up(self.bottom_beads[0], 1)

        return self.build_anim(anim)

    self.enqueue_anim(get_anim)

self.enqueue_anim(lambda : self.reset())

self.play_anims_from_queue()
```

flake8 is clean