### PR TITLE
Drawing gesture recognition

### DIFF
--- a/wandering-warriors/modules/draw_pad.py
+++ b/wandering-warriors/modules/draw_pad.py
@@ -101,7 +101,12 @@ class DrawPad(FloatLayout):
 
             # check if line matches known gesture.
             value = check_gesture(self.ud['lines'][0].points, self.gdb)
-            print(value)
+
+            if value:
+                print(f"Gesture value: {value}")
+                # TODO: report value to relevant module
+                # TODO: fade line out
+                self.click()
 
     def click(self):
         for l in self.lines:

--- a/wandering-warriors/modules/draw_pad.py
+++ b/wandering-warriors/modules/draw_pad.py
@@ -100,8 +100,8 @@ class DrawPad(FloatLayout):
             self.in_pad = False
 
             # check if line matches known gesture.
-            gesture = check_gesture(self.ud['lines'][0].points, self.gdb)
-            print(gesture)
+            value = check_gesture(self.ud['lines'][0].points, self.gdb)
+            print(value)
 
     def click(self):
         for l in self.lines:

--- a/wandering-warriors/modules/draw_pad.py
+++ b/wandering-warriors/modules/draw_pad.py
@@ -2,6 +2,9 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.graphics import Color, Point, GraphicException, Rectangle
 from math import sqrt
 
+from .gesture import check_gesture
+from .gesture_db import load_gestures
+
 
 def calculate_points(x1, y1, x2, y2, steps=1):
     dx = x2 - x1
@@ -20,10 +23,11 @@ def calculate_points(x1, y1, x2, y2, steps=1):
 
 
 class DrawPad(FloatLayout):
-    def __init__(self, ** kwargs):
-        super(DrawPad, self).__init__(** kwargs)
+    def __init__(self, **kwargs):
+        super(DrawPad, self).__init__(**kwargs)
         self.in_pad = False
         self.lines = []
+        self.gdb = load_gestures()
 
         with self.canvas:
             self.border = []
@@ -54,9 +58,9 @@ class DrawPad(FloatLayout):
         super().on_touch_down(touch)
         self.ud = touch.ud
         if (touch.pos[0] > self.pos[0]
-           and touch.pos[0] < self.pos[0] + self.size[0]
-           and touch.pos[1] > self.pos[1]
-           and touch.pos[1] < self.pos[1] + self.size[1]):
+                and touch.pos[0] < self.pos[0] + self.size[0]
+                and touch.pos[1] > self.pos[1]
+                and touch.pos[1] < self.pos[1] + self.size[1]):
             self.in_pad = True
             self.ud['group'] = g = str(touch.uid)
             pointsize = 3
@@ -72,10 +76,10 @@ class DrawPad(FloatLayout):
 
     def on_touch_move(self, touch):
         super().on_touch_move(touch)
-        if(self.in_pad and touch.pos[0] > self.pos[0]
-           and touch.pos[0] < self.pos[0] + self.size[0]
-           and touch.pos[1] > self.pos[1]
-           and touch.pos[1] < self.pos[1] + self.size[1]):
+        if (self.in_pad and touch.pos[0] > self.pos[0]
+                and touch.pos[0] < self.pos[0] + self.size[0]
+                and touch.pos[1] > self.pos[1]
+                and touch.pos[1] < self.pos[1] + self.size[1]):
             self.ud = touch.ud
 
             points = self.ud['lines'][-1].points
@@ -91,11 +95,13 @@ class DrawPad(FloatLayout):
 
     def on_touch_up(self, touch):
         super().on_touch_up(touch)
-        # ud = touch.ud
         if self.in_pad:
             self.lines.append(self.ud['lines'])
             self.in_pad = False
-            # return (self.canvas.get_group(ud['group'])[1].points)
+
+            # check if line matches known gesture.
+            gesture = check_gesture(self.ud['lines'][0].points, self.gdb)
+            print(gesture)
 
     def click(self):
         for l in self.lines:

--- a/wandering-warriors/modules/gesture.py
+++ b/wandering-warriors/modules/gesture.py
@@ -1,7 +1,8 @@
 from kivy.gesture import Gesture
+from .gesture_db import cun_1, cun_10
 
 
-def check_gesture(points, gdb):
+def check_gesture(points, gdb) -> int or None:
     g = Gesture()
 
     # convert raw DrawPad output to gesture compatible list
@@ -12,5 +13,10 @@ def check_gesture(points, gdb):
     # check if new gesture matches a known gesture
     g2 = gdb.find(g, minscore=0.70)
 
-    print(g2[1])
-    return g2
+    if g2:
+        if g2[1] == cun_1:
+            return 1
+        if g2[1] == cun_10:
+            return 10
+
+    return None

--- a/wandering-warriors/modules/gesture.py
+++ b/wandering-warriors/modules/gesture.py
@@ -1,0 +1,16 @@
+from kivy.gesture import Gesture
+
+
+def check_gesture(points, gdb):
+    g = Gesture()
+
+    # convert raw DrawPad output to gesture compatible list
+    point_list = list(zip(points[0::2], points[1::2]))
+    g.add_stroke(point_list)
+    g.normalize()
+
+    # check if new gesture matches a known gesture
+    g2 = gdb.find(g, minscore=0.70)
+
+    print(g2[1])
+    return g2

--- a/wandering-warriors/modules/gesture_db.py
+++ b/wandering-warriors/modules/gesture_db.py
@@ -1,0 +1,49 @@
+from kivy.gesture import GestureDatabase
+
+gdb = GestureDatabase()
+
+cun_1 = gdb.str_to_gesture(
+    "eNp91FtMFFcYwPFFF4QtSrGoWG+0Ul1aXS9V630XtY6K1lWhDirg7jIyK7LLtzsLrPKFNSpGoQ1tNCo2RZPGWDWR+NCEF/EFE3kQrZcmplqrJsY"
+    "+VKMxxsSkPWfynXgyITMvO/nP78w5czYzqaGh2nBD0lOjxY1ETHMp9AuOor2QhjDEraY7HI7GcLWhw1DFe+H0RXdtv0PNYFHXwjW6AU7F+7zS"
+    "/8eRuU/UHFbpTlX1sWh1ImRAuuJzfpf"
+    "+647nr9Vh7HLciEVrtThkVMCwQafeZAIXZLIFZCG43OZc9dFwxIjDBxWQ7R50mJ8DFwxno0Yg5LjVNDaqCT5Uek+uBK2yJdMMSchVvH87S44"
+    "/O5efCOpcj0T4yK2/dzoT91+9LfjlxWESeQij7MVohDFWcW902dOXxWtJ5COMtYq78y9d9P7oIvExwjh7MR5hglXczPWEzpwNkpiIMMleFCB8Yi8"
+    "+RZhsFVff6Nennb9FohDhM3sxBWGqvXAjFJmiw8yPueju+b7zdOoBic8RvrAX0xCm2wsPwgxTtOU0tD/qv8DFiXP5wy"
+    "//VkBiJsIsezEb4UsuvM3lm7uuOW8w0XuppTDv59zZJOYgzLUX8xC+shfzERaY4ge2X4V5nVz0Bv69"
+    "+VO5SmIhwiJTHLmTnfHX1ilc9JnbK1a6GGGJvViK4DXF8RV8n2Jc9Ne97n6jD5DwIRSboouvzlPCxcDU/eyFOUtiGcJyq"
+    "/j9aPJdx8ZGEisQvrYXKxEUq7htvi9rSKxCWG0Vd9P5Qv4hsQahxCruje3j85BYi7DOXnyDsN4q/sw8NutWqScR1NRs/r0KxTQtQp8ffwVscCu"
+    "+A90Ofii+9g7zpBU2yjFFcZMcfRRLpdj2n3m0Qpkct5P8VoqHxfDNUjw0iYarUjx4imS5FFsdFLew+JDivocUt7L4QsQCitvYKD"
+    "/FvX6KFSymKKbEOitZ7KDYYg5Pa4UqFk9RRLGk7SxeodjsIxmQ4h5xz6AUd6dIhqSYFPeslqODpCbFJvF37JBio3j2GjleoajLsYs2OSxHcc"
+    "+dchSLr5WjeMxdchSbXCfFBjF7RI5i9qgcxSbXSzHRQhLkKDYkJkWjimRcinGxIYYchUzIUSy"
+    "+gcUb1tg4mGxisdsak1oiGFCz2LkR3aXFApGQBrsVb88JfnSqTnYhEqjTYI/KPTQngp7/ARKJ1wE= "
+)
+
+cun_10 = gdb.str_to_gesture(
+    "eNp9lHtQlFUUwBdByIUEs4dlKQraYglkpgTafqb5SRmhaG0QLbCsLCG7e/YBLHnjuctLiD8am"
+    "+jFODXDOOXgOE45OrPQ2MSMk4AMZekkf2hNDwend1Mzde7tHIZhmN1/9u7v+917zj3nfNsYbauqrAmkV9i9Pr"
+    "/HbtTpGwxpTRAlYIHJstBgMNRWlvscEK2br5+d+CN+wwJLLEKHvbLC4YMY3TydljCYMpFtSURKJ1ndHle53"
+    "+aDhbqWlJtRtCT7jCUOH3t9HleV3QuxxRA3b+gCJRjhFkxgkQCjScVyuyqdPi/EF0OCad5t+VIwwq24a7GARJMlCnfVQZJuHn"
+    "+r6K9vdrYqEIAlunnqMv5umfSXOaR9m4ClJgd653t6l4Wu/+hA42pV3vp/ppPJuF3AHcr49MLPG1cMHJHGlRt9E10N2WTcKeAuZYQLwfVdwCSNr"
+    "/t/2/H3geNkLBNwtzIGY1edPrTuJ2l8Obx272e74sm4R8DyyMa9Au6TRvgdmca7+6QxYfk"
+    "+qt1ZTMYKASsjG8kCVinjZM7IWP3RJmmMO63GMzFHyFgtIEUZ4QapqNte2O75c"
+    "/+lNWSkClijjBEsUsq2b6Ux0jK59EbfKBlrBdwf2TAJSFPGmKx0iiaN4X/Vh4x1Ah5QxoRsy81j0vi48dzmjGABGQ8KWK"
+    "+Myfqj4mShWxonZFtywmSkC8j438h97cTF6MXSeFNdq5eMTAEPKWP8fdn+a2iEe776MOujXzeRsUHAw8oYUm1JksbQ8tc"
+    "/OT6cSsZGAY9ENjYJ2BzZyBLwaGQjW0COMgKY3S9nB6RxXq6648jYImBrZOMxAebIhiZgm5rCU7b3cA6rpTEuSzrCnXtcwPbIxg4BTyhjRF1gtTS"
+    "+ePuaY+ueLWTsFKBHNnYJyFXGKA6v1XhKGpd+6Pj988pzZDwp4KnIxm4BTyvjorzgsVRpXMb5KW7eTUaegGeUMamVYSYfSONKWCaS5y+zWxLk"
+    "/5XNY7c76e8nvxj2mHSt56ZBfnTt1SS1CMFehGNzYQHCfrmMmtkSgn24dpNJW0KwH9cGho0En9W17kGG"
+    "+QSf07XDYfWa4FM2LbrWNUSB6GkInte1zkba3sWBCnWtvZdgZwnBIl1r6yfYMUTwBV0LzUD1HRWCYl0LThFs5"
+    "+gvItQYJlJ0q661cpXaOHoJQj6zrZfOLEVYwpBTKkOYzDCTTJuutXD0NgOZ5Qi5SqExMu0I8xlyngcQZjLkQBW61syNC3HjHAg5z"
+    "+BVulElQs4zOEjmSwj5zGADmVUIkxhy4w4i5BZTuUJQrWtNXKVgMkEnQr5mkFNyIRybC92zIfcIEA7NhR6EXKVWHkXvbDhF0DcbjtKN"
+    "/LPOnIE1eCPuO7U1BLUIeepaXWTWYeV55lt4PgNYcB7FJjdtr8dh49I1mMl8GWd1mmb+EHfzEM4/T0ighK4p8E3hlGr5Rq/gK2ml7TXc9wZd6"
+    "+VAft7eiDCLoI+3NyHkvvuslFIzwjqGXOQWhHwjL1+zFSHPkpeTDyIcYMhnhhAOzoVts6FGgdrnMztmn8mBOu3+slLLIlz7XAftnlKnzQ5duvn0G"
+    "/LTZ4nBB87Sajsctkgfuv1l6f8BOux3yA== "
+)
+
+
+def load_gestures():
+    gdb = GestureDatabase()
+    gdb.add_gesture(cun_1)
+    gdb.add_gesture(cun_10)
+    print('Loading gestures...')
+
+    return gdb


### PR DESCRIPTION
Kivy's built in gesture recognition algorithms were kicking the crap out of my keras model in reliability.  This method also makes it much easier to add additional gestures on the fly.

gesture_db.py holds a single example of each recognized gesture.  Right now that's just the cunneiform | (1) and > (10).  New gestures can be added to this little db with the gesture_to_str method (after being normalized).  Then we check user drawn lines against all the known gestures and return the value of the gesture it most closely matches (or None if it doesn't meet a threshold for any know gesture.)